### PR TITLE
Reverted option to use both PORT and BUDGETA_UI_PORT in express

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,14 @@ Access:
 
 ### Environment Setup
 
-| env name             | description             | default    |
-|----------------------|-------------------------|------------|
-| BUDGETA_UI_DIST_PATH | path to ui dist folder  | ../ui/dist |
-| BUDGETA_UI_PORT      | express http port       | 3006       |
-| BUDGETA_SDK_API_HOST | spring boot host        | localhost  |
-| BUDGETA_SDK_API_PORT | spring boot http port   | 8080       |
-| BUDGETA_MONGODB_PORT | mongodb port            | 27017      |
-| BUDGETA_MONGODB_HOST | mongodb host            | localhost  |
-| PORT                 | pre def BUDGETA_UI_PORT | 3006       |
+| env name             | description            | set during | default    |
+|----------------------|------------------------|------------|------------|
+| BUDGETA_UI_DIST_PATH | path to ui dist folder | runtime    | ../ui/dist |
+| BUDGETA_UI_PORT      | express http port      | runtime    | 3006       |
+| BUDGETA_SDK_API_HOST | spring boot host       | build time | localhost  |
+| BUDGETA_SDK_API_PORT | spring boot http port  | build time | 8080       |
+| BUDGETA_MONGODB_PORT | mongodb port           | runtime    | 27017      |
+| BUDGETA_MONGODB_HOST | mongodb host           | runtime    | localhost  |
 
 ### Logging
 

--- a/setup/express_server/server.js
+++ b/setup/express_server/server.js
@@ -19,8 +19,7 @@ app.get('*', (req, res) => {
 });
 
 // Start the server
-const port = process.env.PORT || process.env.BUDGETA_UI_PORT || 3006;
+const port = process.env.BUDGETA_UI_PORT || 3006;
 app.listen(port, () => {
   console.log(`Server started on port ${port}`);
-  console.log(`React deployed on http://localhost:${port}`);
 });


### PR DESCRIPTION
Only BUDGETA_UI_PORT is enough even for Azure deployments.